### PR TITLE
fix(vite): define VITE_SERVER_PORT from SERVER_PORT env

### DIFF
--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from "react"
 import VoiceChatRoom from "@/components/voice-chat-room"
 import VoiceOnboarding from "@/components/voice-onboarding"
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000'
+const port = import.meta.env.VITE_SERVER_PORT
+const API_BASE_URL = `http://localhost:${port || 3000}`
 
 interface AgentInfo {
   id: string
@@ -53,6 +54,10 @@ export default function App() {
 
     // Auto-connect after onboarding
     try {
+      console.log("Jsonnnnn",JSON.stringify({
+        roomName: data.roomName,
+        participantName: data.participantName,
+      }))
       const response = await fetch(`${API_BASE_URL}/livekit/token`, {
         method: "POST",
         headers: {
@@ -64,7 +69,11 @@ export default function App() {
         }),
       })
 
+      console.log("repsonseeeee", response);
+
       const result = await response.json()
+
+      console.log("resulttttt", result);
 
       if ('error' in result) {
         throw new Error(result.error)

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -54,10 +54,6 @@ export default function App() {
 
     // Auto-connect after onboarding
     try {
-      console.log("Jsonnnnn",JSON.stringify({
-        roomName: data.roomName,
-        participantName: data.participantName,
-      }))
       const response = await fetch(`${API_BASE_URL}/livekit/token`, {
         method: "POST",
         headers: {
@@ -69,11 +65,7 @@ export default function App() {
         }),
       })
 
-      console.log("repsonseeeee", response);
-
       const result = await response.json()
-
-      console.log("resulttttt", result);
 
       if ('error' in result) {
         throw new Error(result.error)

--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -1,22 +1,31 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
+export default defineConfig(({ mode }) => {
+  const envDir = path.resolve(__dirname, '../../../..')
+  const env = loadEnv(mode, envDir, '')
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3000',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+    define: {
+      'import.meta.env.VITE_SERVER_PORT': JSON.stringify(env.SERVER_PORT || '3000'),
+      global: 'globalThis',
     },
-  },
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
+    },
+  }
 })


### PR DESCRIPTION
Currently, the LiveKit plugin in the GUI only works when the backend server is running on port 3000. This limits flexibility when we want to run the app on a different port.

In this PR, we define VITE_SERVER_PORT in the Vite config and map it to the SERVER_PORT environment variable. This allows the client to dynamically construct the correct API URL based on the configured port.

With this change, we can simply set SERVER_PORT in the environment, and both the GUI and the LiveKit plugin will work seamlessly with the custom port.